### PR TITLE
Incorrect redirect link assigned in login/logout - FIXED

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -2,6 +2,7 @@ v1.1.4
 Tags now show in sidebar of details page - FIXED
 reviews link in details page head will now open reviews tab - FIXED
 Country name does not showing as a translated - FIXED
+Incorrect redirect link assigned in login/logout - FIXED
 
 v1.1.3
 CSS fix for iOS devices for links not working on listing pages - FIXED


### PR DESCRIPTION
- Incorrect redirect link assigned in login/logout - FIXED
See: https://wpgeodirectory.com/support/topic/login-always-pushing-display-one-screen-back/