### PR TITLE
Don't translate GD post types/taxonomies if disabled in WPML settings - CHANGED

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,5 +1,7 @@
 v1.1.7
 Mobile details page tabs now close and scroll to show tab title - CHANGED
+Don't translate GD post types/taxonomies if disabled in WPML settings - CHANGED
+
 
 v1.1.6
 Detail page avatar should work as per discussion default avatar settings - FIXED

--- a/inc/geodirectory-compatibility.php
+++ b/inc/geodirectory-compatibility.php
@@ -793,7 +793,7 @@ function sup_add_feat_img_head($page)
         $post_id = $post->ID;
         
         // WPML
-        $duplicate_of = geodir_is_wpml() ? get_post_meta((int)$post_id, '_icl_lang_duplicate_of', true) : NULL;
+        $duplicate_of = geodir_wpml_is_post_type_translated($post_type) ? get_post_meta((int)$post_id, '_icl_lang_duplicate_of', true) : NULL;
         // WPML
         ?>
         <?php do_action('sd-detail-details-before'); ?>


### PR DESCRIPTION
- Don't translate GD post types/taxonomies if disabled in WPML settings - CHANGED